### PR TITLE
Added alternate section to pre-processing when NCBI downloads fail

### DIFF
--- a/1-PreProcessing/README.md
+++ b/1-PreProcessing/README.md
@@ -86,3 +86,15 @@ Tools used in this analysis are also available from BioConda:
 | `bwa` | [![Anaconda-Server Badge](https://anaconda.org/bioconda/bwa/badges/version.svg)](https://anaconda.org/bioconda/bwa) |
 | `picard` | [![Anaconda-Server Badge](https://anaconda.org/bioconda/picard/badges/version.svg)](https://anaconda.org/bioconda/picard) |
 | `samtools` | [![Anaconda-Server Badge](https://anaconda.org/bioconda/samtools/badges/version.svg)](https://anaconda.org/bioconda/samtools) |
+
+## Alternate Workflow
+
+An alternate starting point has been created for those not wanting to wait for the data to be downloaded from the NCBI SRA. (This can especially be an issue in Australia or Europe.)
+
+There is a shared [history]() containing all of the starting data in appropriate collections and an alternate [workflow]() able to make use of this alternate input. Apart from a slightly different starting point, the workflow and the outputs it produces are identical to that above.
+
+| usegalaxy.org.au |
+|:----------------:|
+| [![Galaxy input history](https://img.shields.io/static/v1?label=history&message=view&color=blue)](https://usegalaxy.org.au/u/simongladman/h/covid-19-raw-data) |
+| [![Galaxy alternate workflow](https://img.shields.io/static/v1?label=workflow&message=run&color=blue)](https://usegalaxy.org.au/u/simongladman/w/covid-19-alternate-pre-processing) |
+| [![Galaxy final history](https://img.shields.io/static/v1?label=history&message=view&color=blue)](https://usegalaxy.org.au/u/simongladman/h/covid-19-alternate-pre-processing) |

--- a/1-PreProcessing/README.md
+++ b/1-PreProcessing/README.md
@@ -91,7 +91,7 @@ Tools used in this analysis are also available from BioConda:
 
 An alternate starting point has been created for those not wanting to wait for the data to be downloaded from the NCBI SRA. (This can especially be an issue in Australia or Europe.)
 
-There is a shared [history]() containing all of the starting data in appropriate collections and an alternate [workflow]() able to make use of this alternate input. Apart from a slightly different starting point, the workflow and the outputs it produces are identical to that above.
+There is a shared [history](https://usegalaxy.org.au/u/simongladman/h/covid-19-raw-data) containing all of the starting data in appropriate collections and an alternate [workflow](https://usegalaxy.org.au/u/simongladman/w/covid-19-alternate-pre-processing) able to make use of this alternate input. Apart from a slightly different starting point, the workflow and the outputs it produces are identical to that above.
 
 | usegalaxy.org.au |
 |:----------------:|

--- a/1-PreProcessing/README.md
+++ b/1-PreProcessing/README.md
@@ -95,6 +95,6 @@ There is a shared [history]() containing all of the starting data in appropriate
 
 | usegalaxy.org.au |
 |:----------------:|
-| [![Galaxy input history](https://img.shields.io/static/v1?label=history&message=view&color=blue)](https://usegalaxy.org.au/u/simongladman/h/covid-19-raw-data) |
+| [![Galaxy input history](https://img.shields.io/static/v1?label=input_history&message=view&color=blue)](https://usegalaxy.org.au/u/simongladman/h/covid-19-raw-data) |
 | [![Galaxy alternate workflow](https://img.shields.io/static/v1?label=workflow&message=run&color=blue)](https://usegalaxy.org.au/u/simongladman/w/covid-19-alternate-pre-processing) |
-| [![Galaxy final history](https://img.shields.io/static/v1?label=history&message=view&color=blue)](https://usegalaxy.org.au/u/simongladman/h/covid-19-alternate-pre-processing) |
+| [![Galaxy final history](https://img.shields.io/static/v1?label=final_history&message=view&color=blue)](https://usegalaxy.org.au/u/simongladman/h/covid-19-alternate-pre-processing) |


### PR DESCRIPTION
I have created an input history on Galaxy Aust that can be used when the NCBI downloads fail. There is an alternate workflow as well for use here. This is because the data is already downloaded in the input history and so that step is not required in the workflow.

