### PR TITLE
GH Edit Links

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -6,6 +6,9 @@ module.exports = {
         extractHeaders: ["h1", "h2", "h3"]
     },
     themeConfig: {
+        repo: 'galaxyproject/SARS-CoV-2',
+        editLinks: true,
+        editLinkText: 'Edit this content on GitHub',
         nav: [
             {
                 text: "Genomics",

--- a/.vuepress/theme/components/NavLinks.vue
+++ b/.vuepress/theme/components/NavLinks.vue
@@ -20,6 +20,7 @@
     </div>
 
     <!-- repo link -->
+    <!--
     <a
       v-if="repoLink"
       :href="repoLink"
@@ -30,6 +31,7 @@
       {{ repoLabel }}
       <OutboundLink />
     </a>
+    -->
   </nav>
 </template>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ---
 sidebar: false
+editLink: false
 ---
 # Analysis of COVID-19 data using Galaxy, BioConda and public research infrastructure
 


### PR DESCRIPTION
This adds 'edit this content on github' links to the footers of the pages.  I disabled the big GitHub link at the top in the navbar to keep that clean and minimal up there, thinking the 'edit this' *after* the content is sufficient.