### PR TITLE
make notebookjs work

### DIFF
--- a/.vuepress/components/JupyterNotebook.vue
+++ b/.vuepress/components/JupyterNotebook.vue
@@ -1,15 +1,12 @@
 <template>
     <div>
         <p>Jupyter Notebook!</p>
-        <div v-html="notebookRender">
-        </div>
+        <div id="mainContent"></div>
     </div>
 </template>
 <script>
-/*
-Quick hack of what an ipython component could work like -- not functional yet.
-*/
-import nb from "notebookjs";
+
+import "!!script-loader!notebookjs";
 import axios from "axios";
 
 export default {
@@ -30,10 +27,9 @@ export default {
         }
     },
     mounted() {
-        // Do this elsewhere, but for now...
         axios.get(this.notebookURL).then(r => {
-            console.debug(r);
-            this.notebookRaw = r;
+            this.notebookRaw = nb.parse(r.data).render();
+            document.getElementById("mainContent").appendChild(this.notebookRaw);
         });
     }
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "notebookjs": "^0.4.2"
   },
   "devDependencies": {
+    "script-loader": "^0.7.2",
     "vuepress": "^1.4.0"
   },
   "scripts": {


### PR DESCRIPTION
This PR makes notebookjs work. Example:

![image](https://user-images.githubusercontent.com/15801412/77792885-7250db00-7069-11ea-809b-2dca422d86ab.png)

However, we still need to adopt it a bit. Intoduce highlighting with Prism, katex and maybe marked.