### PR TITLE
Clean up ipython and change backgroud color

### DIFF
--- a/.vuepress/components/JupyterNotebook.vue
+++ b/.vuepress/components/JupyterNotebook.vue
@@ -1,13 +1,14 @@
 <template>
     <div class="nb-notebook" v-html="notebookHTML"></div>
 </template>
-<style src="./ipython-style.css"></style>
+
 
 <script>
-
 import axios from "axios";
 import "!!script-loader!notebookjs";
-import "prismjs/prism"
+import "prismjs/prism";
+import "prismjs/themes/prism.css";
+import './ipython-style.styl'
 
 export default {
     data: function() {
@@ -23,21 +24,40 @@ export default {
     },
     mounted() {
         axios.get(this.notebookURL).then(r => {
-            nb.ansi_up = require('ansi_up');
-            nb.markdown = require('marked');
-            this.notebookHTML = nb.parse(r.data).render().innerHTML;
-            this.$nextTick(function () {
-                this.highlight()
-            })
+            const nbParser = this.configureNotebookjs();
+            this.notebookHTML = nbParser.parse(r.data).render().innerHTML;
         });
-
     },
     methods: {
-        highlight: function () {
-            require('prismjs/components/prism-python.min');
-            Prism.highlightAll();
+        configureNotebookjs(){
+            nb.ansi_up = require('ansi_up');
+            nb.markdown = require('marked');
+
+            nb.highlighter = ((text, pre, code, lang) => {
+                var language = lang || 'text';
+                pre.className = 'language-' + language;
+                if (typeof code != 'undefined') {
+                    code.className = 'language-' + language;
+                }
+                return this.defineHighlighter(text, language);
+            });
+            return nb;
+        },
+        defineHighlighter(code, lang) {
+            if (typeof lang === 'undefined') lang = 'markup';
+
+            if (!Prism.languages.hasOwnProperty(lang)) {
+                try {
+                    require('prismjs/components/prism-' + lang + '.js');
+                } catch (e) {
+                    console.warn('** failed to load Prism lang: ' + lang);
+                    Prism.languages[lang] = false;
+                }
+            }
+
+            return Prism.languages[lang] ? Prism.highlight(code, Prism.languages[lang]) : code;
         }
     }
-};
+
+}
 </script>
-<style></style>

--- a/.vuepress/components/ipython-style.css
+++ b/.vuepress/components/ipython-style.css
@@ -1,3 +1,0 @@
-.nb-stdout {
-    color: navajowhite;
-}

--- a/.vuepress/components/ipython-style.styl
+++ b/.vuepress/components/ipython-style.styl
@@ -1,0 +1,5 @@
+.theme-default-content
+  pre, pre[class*="language-"]
+    background-color #f5f2f0
+    code
+      color black

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "",
   "dependencies": {
     "axios": "^0.19.2",
-    "notebookjs": "0.4.2",
-    "prismjs": "^1.20.0"
+    "notebookjs": "0.4.2"
   },
   "devDependencies": {
     "script-loader": "^0.7.2",


### PR DESCRIPTION
Clean up the code...
It also took me a while to figure out how to change color and do not intervene other components, but everything should work now. Current look:

![image](https://user-images.githubusercontent.com/15801412/78701062-a8624a80-7906-11ea-88a6-e205c1c732ba.png)

If we ever want to change code background color globally (to white), we would need to modify https://github.com/galaxyproject/SARS-CoV-2/blob/master/.vuepress/styles/palette.styl#L5 

@bgruening Black background still might be more consistent, it not only looks better, but it's defined globally i.e. https://covid19.galaxyproject.org/cheminformatics/deploy/#install-ephemeris

But anyway, it could be merged to master now (at least I hope so). We don't have to decide on global color now.

P.S. creating this PR to https://github.com/galaxyproject/SARS-CoV-2/tree/ipython, cuz I cannot push directly to https://github.com/galaxyproject/SARS-CoV-2/pull/87