### PR TITLE
add information toast

### DIFF
--- a/.vuepress/components/WebinarToast.vue
+++ b/.vuepress/components/WebinarToast.vue
@@ -1,0 +1,24 @@
+<template>
+    Nothing!
+</template>
+<script>
+import Toasted from "vue-toasted";
+import Vue from "vue";
+Vue.use(Toasted, { keepOnHover: true });
+
+export default {
+    mounted() {
+        this.$toasted.show("Join our COVID-19 webinars and learn about data analysis in Galaxy.", {
+            theme: "toasted-primary",
+            duration: 5000,
+            action: {
+                text: "open link",
+                onClick: (e, toastObject) => {
+                    window.open("https://elixir-europe.org/events/webinar-galaxy-elixir-covid19");
+                    toastObject.goAway(0);
+                }
+            }
+        });
+    }
+};
+</script>

--- a/.vuepress/components/WebinarToast.vue
+++ b/.vuepress/components/WebinarToast.vue
@@ -18,15 +18,23 @@ export default {
     mounted() {
         this.$toasted.show(this.message, {
             theme: "toasted-primary",
-            duration: 5000,
+            duration: 10000,
             position: "bottom-right",
-            action: {
-                text: "open link",
-                onClick: (e, toastObject) => {
-                    window.open(this.link);
-                    toastObject.goAway(0);
+            action: [
+                {
+                    text: "more info",
+                    onClick: (e, toastObject) => {
+                        window.open(this.link);
+                        toastObject.goAway(0);
+                    }
+                },
+                {
+                    text: "dismiss",
+                    onClick: (e, toastObject) => {
+                        toastObject.goAway(0);
+                    }
                 }
-            }
+            ]
         });
     }
 };

--- a/.vuepress/components/WebinarToast.vue
+++ b/.vuepress/components/WebinarToast.vue
@@ -1,5 +1,7 @@
-<template>
-    Nothing!
+<template
+    ><div v-show="false">
+        <a :href="link">{{ this.message }}</a>
+    </div>
 </template>
 <script>
 import Toasted from "vue-toasted";
@@ -7,14 +9,21 @@ import Vue from "vue";
 Vue.use(Toasted, { keepOnHover: true });
 
 export default {
+    data() {
+        return {
+            message: "Join our COVID-19 webinars and learn about data analysis in Galaxy.",
+            link: "https://elixir-europe.org/events/webinar-galaxy-elixir-covid19"
+        };
+    },
     mounted() {
-        this.$toasted.show("Join our COVID-19 webinars and learn about data analysis in Galaxy.", {
+        this.$toasted.show(this.message, {
             theme: "toasted-primary",
             duration: 5000,
+            position: "bottom-right",
             action: {
                 text: "open link",
                 onClick: (e, toastObject) => {
-                    window.open("https://elixir-europe.org/events/webinar-galaxy-elixir-covid19");
+                    window.open(this.link);
                     toastObject.goAway(0);
                 }
             }

--- a/.vuepress/theme/components/Navbar.vue
+++ b/.vuepress/theme/components/Navbar.vue
@@ -41,6 +41,9 @@ import AlgoliaSearchBox from '@AlgoliaSearchBox'
 import SearchBox from '@SearchBox'
 import SidebarButton from '@theme/components/SidebarButton.vue'
 import NavLinks from '@theme/components/NavLinks.vue'
+import Toasted from 'vue-toasted';
+import Vue from 'vue'
+Vue.use(Toasted, {keepOnHover: true})
 
 export default {
   name: 'Navbar',
@@ -81,6 +84,18 @@ export default {
     }
     handleLinksWrapWidth()
     window.addEventListener('resize', handleLinksWrapWidth, false)
+
+    this.$toasted.show("Please, consider to attend our SARS-V2 Webinar", {
+      theme: "toasted-primary",
+      duration: 5000,
+      action: {
+        text: 'open link',
+        onClick: (e, toastObject) => {
+          window.open("https://elixir-europe.org/events/webinar-galaxy-elixir-covid19");
+          toastObject.goAway(0);
+        }
+      },
+    })
   }
 }
 

--- a/.vuepress/theme/components/Navbar.vue
+++ b/.vuepress/theme/components/Navbar.vue
@@ -1,109 +1,95 @@
 <template>
-  <header class="navbar">
-    <SidebarButton @toggle-sidebar="$emit('toggle-sidebar')" />
+    <header class="navbar">
+        <SidebarButton @toggle-sidebar="$emit('toggle-sidebar')" />
 
-    <RouterLink
-      :to="$localePath"
-      class="home-link"
-    >
-      <img
-        v-if="$site.themeConfig.logo"
-        class="logo"
-        :src="$withBase($site.themeConfig.logo)"
-        :alt="$siteTitle"
-      >
-      <span
-        v-if="$siteTitle"
-        ref="siteName"
-        class="site-name"
-        :class="{ 'can-hide': $site.themeConfig.logo }"
-      >{{ $siteTitle }}</span>
-    </RouterLink>
+        <RouterLink :to="$localePath" class="home-link">
+            <img
+                v-if="$site.themeConfig.logo"
+                class="logo"
+                :src="$withBase($site.themeConfig.logo)"
+                :alt="$siteTitle"
+            />
+            <span v-if="$siteTitle" ref="siteName" class="site-name" :class="{ 'can-hide': $site.themeConfig.logo }">{{
+                $siteTitle
+            }}</span>
+        </RouterLink>
 
-    <div
-      class="links"
-      :style="linksWrapMaxWidth ? {
-        'max-width': linksWrapMaxWidth + 'px'
-      } : {}"
-    >
-      <AlgoliaSearchBox
-        v-if="isAlgoliaSearch"
-        :options="algolia"
-      />
-      <SearchBox v-else-if="$site.themeConfig.search !== false && $page.frontmatter.search !== false" />
-      <NavLinks class="can-hide" />
-    </div>
-  </header>
+        <div
+            class="links"
+            :style="
+                linksWrapMaxWidth
+                    ? {
+                          'max-width': linksWrapMaxWidth + 'px'
+                      }
+                    : {}
+            "
+        >
+            <AlgoliaSearchBox v-if="isAlgoliaSearch" :options="algolia" />
+            <SearchBox v-else-if="$site.themeConfig.search !== false && $page.frontmatter.search !== false" />
+            <NavLinks class="can-hide" />
+        </div>
+        <ClientOnly>
+            <WebinarToast />
+        </ClientOnly>
+    </header>
 </template>
 
 <script>
-import AlgoliaSearchBox from '@AlgoliaSearchBox'
-import SearchBox from '@SearchBox'
-import SidebarButton from '@theme/components/SidebarButton.vue'
-import NavLinks from '@theme/components/NavLinks.vue'
-import Toasted from 'vue-toasted';
-import Vue from 'vue'
-Vue.use(Toasted, {keepOnHover: true})
+import AlgoliaSearchBox from "@AlgoliaSearchBox";
+import SearchBox from "@SearchBox";
+import SidebarButton from "@theme/components/SidebarButton.vue";
+import NavLinks from "@theme/components/NavLinks.vue";
 
 export default {
-  name: 'Navbar',
+    name: "Navbar",
 
-  components: {
-    SidebarButton,
-    NavLinks,
-    SearchBox,
-    AlgoliaSearchBox
-  },
-
-  data () {
-    return {
-      linksWrapMaxWidth: null
-    }
-  },
-
-  computed: {
-    algolia () {
-      return this.$themeLocaleConfig.algolia || this.$site.themeConfig.algolia || {}
+    components: {
+        SidebarButton,
+        NavLinks,
+        SearchBox,
+        AlgoliaSearchBox
     },
 
-    isAlgoliaSearch () {
-      return this.algolia && this.algolia.apiKey && this.algolia.indexName
-    }
-  },
+    data() {
+        return {
+            linksWrapMaxWidth: null
+        };
+    },
 
-  mounted () {
-    const MOBILE_DESKTOP_BREAKPOINT = 719 // refer to config.styl
-    const NAVBAR_VERTICAL_PADDING = parseInt(css(this.$el, 'paddingLeft')) + parseInt(css(this.$el, 'paddingRight'))
-    const handleLinksWrapWidth = () => {
-      if (document.documentElement.clientWidth < MOBILE_DESKTOP_BREAKPOINT) {
-        this.linksWrapMaxWidth = null
-      } else {
-        this.linksWrapMaxWidth = this.$el.offsetWidth - NAVBAR_VERTICAL_PADDING
-          - (this.$refs.siteName && this.$refs.siteName.offsetWidth || 0)
-      }
-    }
-    handleLinksWrapWidth()
-    window.addEventListener('resize', handleLinksWrapWidth, false)
+    computed: {
+        algolia() {
+            return this.$themeLocaleConfig.algolia || this.$site.themeConfig.algolia || {};
+        },
 
-    this.$toasted.show("Join our COVID-19 webinars and learn about data analysis in Galaxy.", {
-      theme: "toasted-primary",
-      duration: 5000,
-      action: {
-        text: 'open link',
-        onClick: (e, toastObject) => {
-          window.open("https://elixir-europe.org/events/webinar-galaxy-elixir-covid19");
-          toastObject.goAway(0);
+        isAlgoliaSearch() {
+            return this.algolia && this.algolia.apiKey && this.algolia.indexName;
         }
-      },
-    })
-  }
-}
+    },
 
-function css (el, property) {
-  // NOTE: Known bug, will return 'auto' if style value is 'auto'
-  const win = el.ownerDocument.defaultView
-  // null means not to return pseudo styles
-  return win.getComputedStyle(el, null)[property]
+    mounted() {
+        const MOBILE_DESKTOP_BREAKPOINT = 719; // refer to config.styl
+        const NAVBAR_VERTICAL_PADDING =
+            parseInt(css(this.$el, "paddingLeft")) + parseInt(css(this.$el, "paddingRight"));
+        const handleLinksWrapWidth = () => {
+            if (document.documentElement.clientWidth < MOBILE_DESKTOP_BREAKPOINT) {
+                this.linksWrapMaxWidth = null;
+            } else {
+                this.linksWrapMaxWidth =
+                    this.$el.offsetWidth -
+                    NAVBAR_VERTICAL_PADDING -
+                    ((this.$refs.siteName && this.$refs.siteName.offsetWidth) || 0);
+            }
+        };
+        handleLinksWrapWidth();
+        window.addEventListener("resize", handleLinksWrapWidth, false);
+    }
+};
+
+function css(el, property) {
+    // NOTE: Known bug, will return 'auto' if style value is 'auto'
+    const win = el.ownerDocument.defaultView;
+    // null means not to return pseudo styles
+    return win.getComputedStyle(el, null)[property];
 }
 </script>
 

--- a/.vuepress/theme/components/Navbar.vue
+++ b/.vuepress/theme/components/Navbar.vue
@@ -85,7 +85,7 @@ export default {
     handleLinksWrapWidth()
     window.addEventListener('resize', handleLinksWrapWidth, false)
 
-    this.$toasted.show("Please, consider to attend our SARS-V2 Webinar", {
+    this.$toasted.show("Join our COVID-19 webinars and learn about data analysis in Galaxy.", {
       theme: "toasted-primary",
       duration: 5000,
       action: {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
   "author": "",
   "license": "AFL-3.0",
   "dependencies": {
-    "gh-badges": "^2.2.1",
     "@observablehq/runtime": "^4.7.0",
-    "uuid": "^7.0.2"
+    "gh-badges": "^2.2.1",
+    "uuid": "^7.0.2",
+    "vue-toasted": "^1.1.28"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7508,6 +7508,11 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
+vue-toasted@^1.1.28:
+  version "1.1.28"
+  resolved "https://registry.yarnpkg.com/vue-toasted/-/vue-toasted-1.1.28.tgz#dbabb83acc89f7a9e8765815e491d79f0dc65c26"
+  integrity sha512-UUzr5LX51UbbiROSGZ49GOgSzFxaMHK6L00JV8fir/CYNJCpIIvNZ5YmS4Qc8Y2+Z/4VVYRpeQL2UO0G800Raw==
+
 vue@^2.6.10:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"


### PR DESCRIPTION
As @bgruening suggested. It would be great to have a short notification about current webinars.
I thought, it would be a good idea to use vue-toast for this.

Current look:
![image](https://user-images.githubusercontent.com/15801412/81352907-00d46580-90c8-11ea-8e78-c68f53b63b98.png)

Behavior:
- The toast will disappear after 5 seconds, unless the user hovers his mouse over it.
- It will appear on at every path, but only once per session
- Button will open a new tab (currently [this link](https://elixir-europe.org/events/webinar-galaxy-elixir-covid19))