### PR TITLE
Fix observable component multi-embed

### DIFF
--- a/.vuepress/components/observableNotebook.vue
+++ b/.vuepress/components/observableNotebook.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div id="hotlinkedNotebookDock"></div>
+        <div ref="hotlinkedNotebookDock"></div>
         <p>Source notebook: <a :href="getNotebookSource">{{getNotebookSource}}</a></p>
     </div>
 </template>
@@ -20,6 +20,8 @@ export default {
     },
     mounted() {
         let notebookScript = document.createElement("script");
+        console.debug(this.$refs.hotlinkedNotebookDock);
+        this.$refs.hotlinkedNotebookDock.id = this._uid;
         notebookScript.type = "module";
         notebookScript.async = true;
         notebookScript.innerHTML = `
@@ -30,7 +32,7 @@ export default {
 
         // Load the notebook, observing its cells with a default Inspector
         // that simply renders the value of each cell into the provided DOM node.
-        new Runtime().module(notebook, Inspector.into(document.getElementById('hotlinkedNotebookDock')));
+        new Runtime().module(notebook, Inspector.into(document.getElementById('${ this._uid }')));
     `;
         document.head.appendChild(notebookScript);
     }

--- a/.vuepress/components/observableNotebook.vue
+++ b/.vuepress/components/observableNotebook.vue
@@ -1,7 +1,9 @@
 <template>
     <div>
         <div ref="hotlinkedNotebookDock"></div>
-        <p>Source notebook: <a :href="getNotebookSource">{{getNotebookSource}}</a></p>
+        <p>
+            Source notebook: <a :href="getNotebookSource">{{ getNotebookSource }}</a>
+        </p>
     </div>
 </template>
 
@@ -14,13 +16,12 @@ export default {
         }
     },
     computed: {
-      getNotebookSource() {
-        return `https://observablehq.com/${this.notebookSource}`;
-      }
+        getNotebookSource() {
+            return `https://observablehq.com/${this.notebookSource}`;
+        }
     },
     mounted() {
         let notebookScript = document.createElement("script");
-        console.debug(this.$refs.hotlinkedNotebookDock);
         this.$refs.hotlinkedNotebookDock.id = this._uid;
         notebookScript.type = "module";
         notebookScript.async = true;
@@ -32,7 +33,7 @@ export default {
 
         // Load the notebook, observing its cells with a default Inspector
         // that simply renders the value of each cell into the provided DOM node.
-        new Runtime().module(notebook, Inspector.into(document.getElementById('${ this._uid }')));
+        new Runtime().module(notebook, Inspector.into(document.getElementById('${this._uid}')));
     `;
         document.head.appendChild(notebookScript);
     }


### PR DESCRIPTION
This fixes the observable component embed when more than one notebook are on the page at a time (`/genomics/5-annotation/`)